### PR TITLE
What's up npm? Cannot publish over previously published version "2.0.0"???

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-d3-modifiers",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
What's up npm? 400 Bad Request - PUT https://registry.npmjs.org/ember-d3-modifiers - Cannot publish over previously published version "2.0.0"